### PR TITLE
Agrego prettier y actualizo el README

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+**/node_modules
+**/public
+**/package.json
+**/package-lock.json
+*.drawio

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,7 @@
+trailingComma: "es5"
+tabWidth: 4
+printWidth: 80
+plugins: ["prettier-plugin-sql", "prettier-plugin-prisma"]
+
+# prettier-plugin-sql config
+language: postgresql

--- a/README.md
+++ b/README.md
@@ -1,38 +1,43 @@
-# Final Assignment WEB Development 
+# Final Assignment WEB Development
+
 Final assignment for the "Introducción al Desarrollo de Software" subject of the
 Computer Engineering degree of the University of Buenos Aires.
 
 ## Technologies
-* Frontend:
-    * HTML
-    * CSS (Bulma Framework)
-    * JS (Vanilla)
-* Backend:
-    * express
-    * PrismaORM
-    * MariaDB
+
+- Frontend:
+    - HTML
+    - CSS
+    - JS
+- Backend:
+    - express
+    - PrismaORM
+    - PostgreSQL
 
 ## Conventions
-Code and documentation will be in English whereas issues, reviews, and other 
-discussions will be in Spanish. Tasks will be tracked on [Trello][1], and 
+
+Code and documentation will be in English whereas issues, reviews, and other
+discussions will be in Spanish. Tasks will be tracked on [Trello][1], and
 patches will be merged once all team members have reviewed them.
 
 ## Collaborators
-* Fernandez, Jose Luis 
-* Kupa, Martin Ariel
-* Fasani, Ignacio Daniel
-* Argerich, Mariano
+
+- Fernandez, Jose Luis
+- Kupa, Martin Ariel
+- Fasani, Ignacio Daniel
+- Argerich, Mariano
 
 ## Assignment requirements
-* A web application with Client-Side Rendering and at least three views
-* A REST api supporting basic CRUD operations
-* Public deployment and hosting of the application
-* Use of git and github with a clean commit history
-* Persistent state in a relational database
 
+- A web application with Client-Side Rendering and at least three views
+- A REST api supporting basic CRUD operations
+- Public deployment and hosting of the application
+- Use of git and github with a clean commit history
+- Persistent state in a relational database
 
-## Build and Deployment
-* TODO
+## Tooling
 
+- Docker
+- Prettier
 
 [1]: https://trello.com/b/FrVAu7L0/tp2-intro "Trello"

--- a/docs/sticker-album.md
+++ b/docs/sticker-album.md
@@ -1,21 +1,26 @@
 # Ideas for a virtual sticker album
 
 ## Game Objective
+
 Get all the stickers
 
 ## Mechanics
+
 The game will include
-* Sticker packs
-* Private/Public trades
-* Free sticker pack every day
+
+- Sticker packs
+- Private/Public trades
+- Free sticker pack every day
 
 The game may also include
-* Card fusion
-* Secret codes (DNI)
-* An in-game currency for buying sticker packs or sticker cards directly
+
+- Card fusion
+- Secret codes (DNI)
+- An in-game currency for buying sticker packs or sticker cards directly
 
 ## Themes
-* Cartoon Network characters
-* Dragon ball/anime
-* Superheroes
-* _Breaking bad characters_ (chosen)
+
+- Cartoon Network characters
+- Dragon ball/anime
+- Superheroes
+- _Breaking bad characters_ (chosen)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,208 @@
+{
+  "name": "tp2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "prettier": "^3.4.2",
+        "prettier-plugin-prisma": "^5.0.0",
+        "prettier-plugin-sql": "^0.18.1"
+      }
+    },
+    "node_modules/@prisma/prisma-schema-wasm": {
+      "version": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-schema-wasm/-/prisma-schema-wasm-4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584.tgz",
+      "integrity": "sha512-JFdsnSgBPN8reDTLOI9Vh/6ccCb2aD1LbY/LWQnkcIgNo6IdpzvuM+qRVbBuA6IZP2SdqQI8Lu6RL2P8EFBQUA==",
+      "dev": true
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "dev": true
+    },
+    "node_modules/get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jsox": {
+      "version": "1.2.121",
+      "resolved": "https://registry.npmjs.org/jsox/-/jsox-1.2.121.tgz",
+      "integrity": "sha512-9Ag50tKhpTwS6r5wh3MJSAvpSof0UBr39Pto8OnzFT32Z/pAbxAsKHzyvsyMEHVslELvHyO/4/jaQELHk8wDcw==",
+      "dev": true,
+      "bin": {
+        "jsox": "lib/cli.js"
+      }
+    },
+    "node_modules/moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
+      "dev": true
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
+    "node_modules/node-sql-parser": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-4.18.0.tgz",
+      "integrity": "sha512-2YEOR5qlI1zUFbGMLKNfsrR5JUvFg9LxIRVE+xJe962pfVLH0rnItqLzv96XVs1Y1UIR8FxsXAuvX/lYAWZ2BQ==",
+      "dev": true,
+      "dependencies": {
+        "big-integer": "^1.6.48"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-prisma": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-prisma/-/prettier-plugin-prisma-5.0.0.tgz",
+      "integrity": "sha512-jTJV04D9+yF7ziOOMs7CJe4ijgAH7DEGjt0SAWAToGNRy1H6BEhvcKA2UQH6gC6KVW5zeeOSAvsoiDDTt9oKXg==",
+      "dev": true,
+      "dependencies": {
+        "@prisma/prisma-schema-wasm": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=8"
+      },
+      "peerDependencies": {
+        "prettier": ">=2 || >=3"
+      }
+    },
+    "node_modules/prettier-plugin-sql": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-sql/-/prettier-plugin-sql-0.18.1.tgz",
+      "integrity": "sha512-2+Nob2sg7hzLAKJoE6sfgtkhBZCqOzrWHZPvE4Kee/e80oOyI4qwy9vypeltqNBJwTtq3uiKPrCxlT03bBpOaw==",
+      "dev": true,
+      "dependencies": {
+        "jsox": "^1.2.119",
+        "node-sql-parser": "^4.12.0",
+        "sql-formatter": "^15.0.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.3"
+      }
+    },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "dev": true
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dev": true,
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/sql-formatter": {
+      "version": "15.4.6",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-15.4.6.tgz",
+      "integrity": "sha512-aH6kwvJpylljHqXe+zpie0Q5snL3uerDLLhjPEBjDCVK1NMRFq4nMJbuPJWYp08LaaaJJgBhShAdAfspcBYY0Q==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "get-stdin": "=8.0.0",
+        "nearley": "^2.20.1"
+      },
+      "bin": {
+        "sql-formatter": "bin/sql-formatter-cli.cjs"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "devDependencies": {
+    "prettier": "^3.4.2",
+    "prettier-plugin-prisma": "^5.0.0",
+    "prettier-plugin-sql": "^0.18.1"
+  }
+}


### PR DESCRIPTION
Prettier es una herramienta para formatear el código y facilita mantener un estilo consistente. Lo configure para que trabaje con SQL y prisma. Para formatear el codigo del repo ejecuten

> $ npx prettier -w .

Ojo que la opción -w les modifica los archivos. En un futuro la idea seria implementar una acción de github que ejecute el comando automáticamente para cada PR, pero por el momento ejecútenlo a mano antes de pushear.